### PR TITLE
Fix namespace handling in each statements with path expressions in its body

### DIFF
--- a/dist/blockStatements.js
+++ b/dist/blockStatements.js
@@ -28,8 +28,7 @@ exports.resolveBlockStatement = function (blockStatement) {
  */
 exports.createConditionStatement = function (blockStatement, invertCondition) {
     var program = blockStatement.program, inverse = blockStatement.inverse;
-    var boolCondSubject = Babel.callExpression(Babel.identifier('Boolean'), [expressions_1.resolveExpression(blockStatement.params[0])] //
-    );
+    var boolCondSubject = Babel.callExpression(Babel.identifier('Boolean'), [expressions_1.resolveExpression(blockStatement.params[0])]);
     if (invertCondition) {
         boolCondSubject = Babel.unaryExpression('!', boolCondSubject);
     }

--- a/dist/pathsPrepare.js
+++ b/dist/pathsPrepare.js
@@ -1,7 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 var syntax_1 = require("@glimmer/syntax");
-var hash = require("object-hash");
 var contants_1 = require("./contants");
 /**
  * Checks is each statement
@@ -23,7 +22,6 @@ var createNamespaceStack = function () {
         push: function (item) {
             return namespaces.push({
                 node: item.node,
-                hash: hash(item.node),
                 name: item.name || contants_1.DEFAULT_NAMESPACE_NAME
             });
         },
@@ -57,7 +55,7 @@ exports.prepareProgramPaths = function (program, isComponent) {
             },
             exit: function (node) {
                 // Exit from namespace
-                if (namespaces.length > 0 && hash(node) === namespaces.head().hash) {
+                if (namespaces.length > 0 && node === namespaces.head().node) {
                     namespaces.pop();
                 }
             }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@babel/types": "^7.1.3",
     "@glimmer/syntax": "^0.36.5",
     "is-self-closing": "^1.0.1",
-    "object-hash": "^1.3.0",
     "prettier": "^1.14.3",
     "react-attr-converter": "^0.3.1",
     "reserved-words": "^0.1.2"

--- a/src/pathsPrepare.ts
+++ b/src/pathsPrepare.ts
@@ -1,5 +1,4 @@
 import { AST as Glimmer, traverse } from '@glimmer/syntax'
-import * as hash                    from 'object-hash'
 import { DEFAULT_NAMESPACE_NAME }   from './contants'
 
 /**
@@ -12,7 +11,7 @@ const isEachStatement = (node: Glimmer.Node): node is Glimmer.BlockStatement =>
  * Creates stack of namespaces
  */
 const createNamespaceStack = () => {
-  const namespaces: { node: Glimmer.Node; name: string; hash: string }[] = []
+  const namespaces: { node: Glimmer.Node; name: string }[] = []
 
   return {
     // Getter of length
@@ -24,7 +23,6 @@ const createNamespaceStack = () => {
     push: (item: { node: Glimmer.Node; name?: string }) =>
       namespaces.push({
         node: item.node,
-        hash: hash(item.node),
         name: item.name || DEFAULT_NAMESPACE_NAME
       }),
 
@@ -64,7 +62,7 @@ export const prepareProgramPaths = (program: Glimmer.Program, isComponent: boole
       },
       exit(node: Glimmer.Node) {
         // Exit from namespace
-        if (namespaces.length > 0 && hash(node) === namespaces.head().hash) {
+        if (namespaces.length > 0 && node === namespaces.head().node) {
           namespaces.pop()
         }
       }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -185,6 +185,12 @@ describe('block statements', () => {
       )
     })
 
+    test('siblings each block statements with path expression - no component', () => {
+      expect(compile('<div>{{#each list}}<div>{{name}}</div>{{/each}}{{#each list}}<div>{{name}}</div>{{/each}}</div>', false)).toBe(
+        '<div>{list.map((item, i) => <div key={i}>{item.name}</div>)}{list.map((item, i) => <div key={i}>{item.name}</div>)}</div>;'
+      )
+    })
+
     test('should wrap multiple block children into fragment with keys', () => {
       expect(compile('<div>{{#each list}}<div /><span /> Text{{/each}}</div>')).toBe(
         'props => <div>{props.list.map((item, i) => <React.Fragment key={i}><div /><span /> Text</React.Fragment>)}</div>;'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,11 +3186,6 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-hash@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
-  integrity sha512-05KzQ70lSeGSrZJQXE5wNDiTkBJDlUT/myi6RX9dVIvz7a7Qh4oH93BQdiPMn27nldYvVQCKMUaM83AfizZlsQ==
-
 object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"


### PR DESCRIPTION
The namespace added in `each` statement is not being removed when there are one or more `path expressions` in its body.

This occurs because is comparing the node hash calculated at the time the namespace is added with the node hash calculated at `each` statement exit. This checks fails when there are `path expressions` because  it modifies the node definition making the hash calculated at exit different from the one when namespace is added.

This checks the node instance directly, allowing to remove the dependency on object-hash package