### PR TITLE
feature: expressions in styles

### DIFF
--- a/dist/elements.js
+++ b/dist/elements.js
@@ -39,6 +39,10 @@ exports.createAttribute = function (attrNode) {
         }
         case 'ConcatStatement': {
             var expression = expressions_1.createConcat(value.parts);
+            if (reactAttrName === 'style') {
+                var styleObjectExpression = styles_1.parseStyleConcat(value);
+                return Babel.jsxAttribute(name, Babel.jsxExpressionContainer(styleObjectExpression));
+            }
             return Babel.jsxAttribute(name, Babel.jsxExpressionContainer(expression));
         }
         default: {

--- a/dist/styles.js
+++ b/dist/styles.js
@@ -27,3 +27,40 @@ exports.createStyleObject = function (style) {
  * @param style Styles string
  */
 exports.parseStyleString = function (style) { return parser_1.parseExpression(JSON.stringify(exports.createStyleObject(style))); };
+/**
+ * Create AST tree of style object from style concat
+ */
+exports.parseStyleConcat = function (concatStatement) {
+    var styleObjectExpressionString = '{';
+    var lastStyleAttr = '';
+    var lastVariableValue = '';
+    concatStatement.parts.forEach(function (part) {
+        if (part.type === 'TextNode') {
+            var stylePropList_1 = part.chars.split(';');
+            stylePropList_1.forEach(function (styleProp) {
+                var ruleSplit = styleProp.split(':').map(function (str) { return str.trim(); });
+                // a part of the value recently found in MustacheStatement
+                if (ruleSplit.length === 1) {
+                    styleObjectExpressionString += "\"" + exports.camelizePropName(lastStyleAttr.trim()) + "\": ";
+                    styleObjectExpressionString += '`${' + lastVariableValue + '}' + stylePropList_1[0] + '`,';
+                    lastStyleAttr = '';
+                    lastVariableValue = '';
+                }
+                if (ruleSplit.length === 2) {
+                    var styleAttr = ruleSplit[0], styleValue = ruleSplit[1];
+                    if (!!styleAttr && !!styleValue) {
+                        styleObjectExpressionString += "\"" + exports.camelizePropName(styleAttr.trim()) + "\": \"" + styleValue + "\",";
+                    }
+                    if (!!styleAttr && !styleValue) {
+                        lastStyleAttr = styleAttr;
+                    }
+                }
+            });
+        }
+        if (part.type === 'MustacheStatement' && part.path.type === 'PathExpression') {
+            lastVariableValue = part.path.parts.join('.');
+        }
+    });
+    styleObjectExpressionString += '}';
+    return parser_1.parseExpression(styleObjectExpressionString);
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest",
-    "build": "tsc"
+    "build": "tsc --skipLibCheck"
   },
   "keywords": [
     "handlebars",

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -3,7 +3,7 @@ import * as Babel                                          from '@babel/types'
 import * as isSelfClosing                                  from 'is-self-closing'
 import * as convertHTMLAttribute                           from 'react-attr-converter'
 import { createConcat, resolveExpression, createChildren } from './expressions'
-import { parseStyleString }                                from './styles'
+import { parseStyleString, parseStyleConcat }                                from './styles'
 
 /**
  * Creates JSX fragment
@@ -53,6 +53,10 @@ export const createAttribute = (attrNode: Glimmer.AttrNode): Babel.JSXAttribute 
 
     case 'ConcatStatement': {
       const expression = createConcat(value.parts)
+      if (reactAttrName === 'style') {
+        const styleObjectExpression = parseStyleConcat(value);
+        return Babel.jsxAttribute(name, Babel.jsxExpressionContainer(styleObjectExpression))
+      }
 
       return Babel.jsxAttribute(name, Babel.jsxExpressionContainer(expression))
     }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -1,4 +1,5 @@
 import { parseExpression } from '@babel/parser'
+import { ConcatStatement } from '@glimmer/syntax/dist/types/lib/types/nodes';
 
 /**
  * Transforms "prop-name" to "propName"
@@ -34,3 +35,42 @@ export const createStyleObject = (style: string): Record<string, string | number
  * @param style Styles string
  */
 export const parseStyleString = (style: string) => parseExpression(JSON.stringify(createStyleObject(style)))
+
+/**
+ * Create AST tree of style object from style concat
+ */
+export const parseStyleConcat = (concatStatement: ConcatStatement) => {
+  let styleObjectExpressionString = '{';
+  let lastStyleAttr = '';
+  let lastVariableValue = '';
+  concatStatement.parts.forEach(part => {
+    if (part.type === 'TextNode') {
+      const stylePropList = part.chars.split(';');
+      stylePropList.forEach(styleProp => {
+        const ruleSplit = styleProp.split(':').map(str => str.trim());
+        // a part of the value recently found in MustacheStatement
+        if (ruleSplit.length === 1) {
+          styleObjectExpressionString += `"${camelizePropName(lastStyleAttr.trim())}": `;
+          styleObjectExpressionString += '`${' + lastVariableValue + '}' + stylePropList[0] + '`,';
+          lastStyleAttr = '';
+          lastVariableValue = '';
+        }
+        if (ruleSplit.length === 2) {
+          const [styleAttr, styleValue] = ruleSplit;
+          if (!!styleAttr && !!styleValue) {
+            styleObjectExpressionString += `"${camelizePropName(styleAttr.trim())}": "${styleValue}",`;
+          }
+          if (!!styleAttr && !styleValue) {
+            lastStyleAttr = styleAttr;
+          }
+        }
+        
+      })
+    }
+    if (part.type === 'MustacheStatement' && part.path.type === 'PathExpression') {
+      lastVariableValue = part.path.parts.join('.');
+    }
+  });
+  styleObjectExpressionString += '}';
+  return parseExpression(styleObjectExpressionString);
+}

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -109,8 +109,11 @@ describe('element attributes', () => {
   })
 
   test('should convert the "styles" string to stylesObject', () => {
-    expect(compile('<div style="background-image: url(\'image.png\'); margin-left: 10px; width: {{some.percentage}}px; margin-top: 10px; padding: {{padding}}px" />', false)).toBe(
-      recompile('<div style={{ "backgroundImage": "url(\'image.png\')", "marginLeft": "10px", "width": `${some.percentage}px`, "marginTop": "10px", "padding": `${padding}px` }} />')
+    expect(compile('<div style="background-image: url(\'image.png\'); margin-left: 10px" />', false)).toBe(
+      recompile('<div style={{ "backgroundImage": "url(\'image.png\')", "marginLeft": "10px" }} />')
+    )
+    expect(compile('<div style="background-image: url(\'{{some.imageSrc}}\'); margin-left: 10px; width: {{some.percentage}}px; margin-top: 10px; text-align: {{textAlign}}" />', false)).toBe(
+      recompile('<div style={{ "backgroundImage": `url(\'${some.imageSrc}\')`, "marginLeft": "10px", "width": `${some.percentage}px`, "marginTop": "10px", "textAlign": `${textAlign}` }} />')
     )
   })
 })

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -109,8 +109,8 @@ describe('element attributes', () => {
   })
 
   test('should convert the "styles" string to stylesObject', () => {
-    expect(compile('<div style="background-image: url(\'image.png\'); margin-left: 10px" />', false)).toBe(
-      recompile('<div style={{ "backgroundImage": "url(\'image.png\')", "marginLeft": "10px" }} />')
+    expect(compile('<div style="background-image: url(\'image.png\'); margin-left: 10px; width: {{some.percentage}}px; margin-top: 10px; padding: {{padding}}px" />', false)).toBe(
+      recompile('<div style={{ "backgroundImage": "url(\'image.png\')", "marginLeft": "10px", "width": `${some.percentage}px`, "marginTop": "10px", "padding": `${padding}px` }} />')
     )
   })
 })


### PR DESCRIPTION
## Summary

This PR is intended to solve #2. Pardon the formatting as I couldn't find any formatting config attached. Added ` --skipLibCheck` to the build script as it would always fail without it.

Intended to support the following statements:
- [x] `width: {{percentage}}px`
- [x] `background-image: url("{{bgImage}}")`
- [x] `text-align: {{textAlign}}`